### PR TITLE
PDF Invoices & Packing Slips for WooCommerce compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ For more details, please refer to the [Saudi Central Bank announcement](https://
 
 ## Changelog
 
+### 1.6
+- Add PDF Invoices & Packing Slips for WooCommerce Compatibility.
+
 ### 1.5
 - Fixed currency symbol display in RTL emails.
 

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,12 @@ For more details, please refer to the [Saudi Central Bank announcement](https://
 
 لمزيد من التفاصيل، يرجى مراجعة [إعلان البنك المركزي السعودي](https://www.sama.gov.sa/en-US/Currency/SRS/Pages/default.aspx).
 
+## Features
+- Replaces the old Saudi Riyal symbol with the official Saudi Riyal symbol.
+- Displays the updated symbol on the front-end, in WooCommerce emails, and in PDF invoices ( Compatible with PDF Invoices & Packing Slips for WooCommerce plugin ).
+- Supports RTL environments by forcing the symbol to appear on the left.
+- Support block-based themes.
+
 ## Changelog
 
 ### 1.6

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,9 @@ A plugin that replaces the old Saudi Riyal symbol with the new one on WooCommerc
 
 == Changelog ==
 
+= 1.6 =
+- Add PDF Invoices & Packing Slips for WooCommerce Compatibility.
+
 = 1.5 =
 - Fixed currency symbol display in RTL emails.
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,12 @@ A plugin that replaces the old Saudi Riyal symbol with the new one on WooCommerc
 اضافة ووردبريس تقوم باستبدال رمز عملة الريال السعودي ر.س بالرمز الجديد الذي تم اطلاقه من قبل البنك المركزي السعودي.
 لمزيد من التفاصيل، يرجى مراجعة [إعلان البنك المركزي السعودي](https://www.sama.gov.sa/en-US/Currency/SRS/Pages/default.aspx).
 
+== Features ==
+- Replaces the old Saudi Riyal symbol with the official Saudi Riyal symbol.
+- Displays the updated symbol on the front-end, in WooCommerce emails, and in PDF invoices ( Compatible with PDF Invoices & Packing Slips for WooCommerce plugin ).
+- Supports RTL environments by forcing the symbol to appear on the left.
+- Support block-based themes.
+
 == Changelog ==
 
 = 1.6 =

--- a/saudi-riyal-symbol-for-woocommerce.php
+++ b/saudi-riyal-symbol-for-woocommerce.php
@@ -101,7 +101,11 @@ add_filter( 'option_woocommerce_currency_pos', 'nsrwc_woocommerce_currency_pos',
  * @return string
  */
 function nsrwc_wrap_currency_symbol( $format, $currency_pos ) {
-	if ( nsrwc_is_doing_email() || 'SAR' !== get_woocommerce_currency() ) {
+	if ( nsrwc_is_doing_pdf() ) {
+		return class_exists( 'WCPDF_Custom_PDF_Maker_mPDF' ) ? '%2$s&nbsp;%1$s' : $format;
+	}
+
+	if ( 'SAR' !== get_woocommerce_currency() || nsrwc_is_doing_email() ) {
 		return $format;
 	}
 
@@ -123,14 +127,14 @@ function nsrwc_replace_sar_currency_symbol( $currency_symbol, $currency ) {
 		return $currency_symbol;
 	}
 
-	if ( nsrwc_is_doing_email() ) {
-		return '<img src="' . plugins_url( 'assets/saudi-riyal-font/Saudi_Riyal_Symbol-1.png', __FILE__ ) . '" alt="' . $currency_symbol . '" style="vertical-align: middle; margin: 0 !important; height: 1em; font-size: inherit !important;">';
+	if ( nsrwc_is_doing_email() || nsrwc_is_doing_pdf() ) {
+		return '<img src="' . plugins_url( 'assets/saudi-riyal-font/Saudi_Riyal_Symbol-1.png', __FILE__ ) . '" alt="' . $currency . '" style="vertical-align: middle; margin: 0 !important; height: 1em; font-size: inherit !important;">';
 	}
 
 	return '&#xe900;';
 }
 
-add_filter( 'woocommerce_currency_symbol', 'nsrwc_replace_sar_currency_symbol', 9999, 2 );
+add_filter( 'woocommerce_currency_symbol', 'nsrwc_replace_sar_currency_symbol', 10002, 2 );
 
 /**
  * Add css style to emails.
@@ -178,6 +182,23 @@ function nsrwc_is_doing_email() {
 		doing_action( 'woocommerce_email_order_details' ) ||
 		doing_action( 'woocommerce_email_order_meta' ) ||
 		did_action( 'woocommerce_before_email_order' )
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Check if it is a PDF file.
+ *
+ * @return bool
+ */
+function nsrwc_is_doing_pdf() {
+	if (
+		wp_doing_ajax() &&
+		isset( $_GET['action'] ) &&
+		'generate_wpo_wcpdf' === $_GET['action']
 	) {
 		return true;
 	}


### PR DESCRIPTION
Make the plugin compatible with [PDF Invoices & Packing Slips for WooCommerce ](https://wordpress.org/plugins/woocommerce-pdf-invoices-packing-slips/) plugin
<img width="381" alt="image" src="https://github.com/user-attachments/assets/00ad3f77-72e8-4c56-903c-b97de748ab7f" />
