### PR TITLE
Challan – PDF Invoice & Packing Slip for WooCommerce compatibilty

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,9 @@ For more details, please refer to the [Saudi Central Bank announcement](https://
 
 ## Changelog
 
+### 1.7
+- Add `Challan - PDF Invoice & Packing Slip for WooCommerce` compatibility.
+
 ### 1.6
 - Add PDF Invoices & Packing Slips for WooCommerce Compatibility.
 

--- a/readme.txt
+++ b/readme.txt
@@ -19,11 +19,19 @@ A plugin that replaces the old Saudi Riyal symbol with the new one on WooCommerc
 
 == Features ==
 - Replaces the old Saudi Riyal symbol with the official Saudi Riyal symbol.
-- Displays the updated symbol on the front-end, in WooCommerce emails, and in PDF invoices ( Compatible with PDF Invoices & Packing Slips for WooCommerce plugin ).
+- Displays the updated symbol on the front-end, in WooCommerce emails, and in PDF invoices.
 - Supports RTL environments by forcing the symbol to appear on the left.
 - Support block-based themes.
 
+== Compatible With ==
+- WooCommerce emails.
+- PDF Invoices & Packing Slips for WooCommerce plugin.
+- Challan - PDF Invoice & Packing Slip for WooCommerce plugin.
+
 == Changelog ==
+
+= 1.7 =
+- Add `Challan - PDF Invoice & Packing Slip for WooCommerce` compatibility.
 
 = 1.6 =
 - Add PDF Invoices & Packing Slips for WooCommerce Compatibility.

--- a/saudi-riyal-symbol-for-woocommerce.php
+++ b/saudi-riyal-symbol-for-woocommerce.php
@@ -96,11 +96,10 @@ add_filter( 'option_woocommerce_currency_pos', 'nsrwc_woocommerce_currency_pos',
  * Wrap currency symbol with a span.
  *
  * @param $format
- * @param $currency_pos
  *
  * @return string
  */
-function nsrwc_wrap_currency_symbol( $format, $currency_pos ) {
+function nsrwc_wrap_currency_symbol( $format ) {
 	if ( nsrwc_is_doing_pdf() ) {
 		return class_exists( 'WCPDF_Custom_PDF_Maker_mPDF' ) ? '%2$s&nbsp;%1$s' : $format;
 	}
@@ -112,7 +111,7 @@ function nsrwc_wrap_currency_symbol( $format, $currency_pos ) {
 	return str_replace( '%1$s', '<span class="sar-currency-symbol">%1$s</span>', $format );
 }
 
-add_filter( 'woocommerce_price_format', 'nsrwc_wrap_currency_symbol', 9999, 2 );
+add_filter( 'woocommerce_price_format', 'nsrwc_wrap_currency_symbol', 9999, 1 );
 
 /**
  * Replace SAR currency symbol.
@@ -143,7 +142,7 @@ add_filter( 'woocommerce_currency_symbol', 'nsrwc_replace_sar_currency_symbol', 
  *
  * @return string
  */
-function nsrwc_email_styles_filter( $css, $email ) {
+function nsrwc_email_styles_filter( $css ) {
 	// Fix emails amount direction.
 	$css .= "
 	.woocommerce-Price-amount {
@@ -155,7 +154,7 @@ function nsrwc_email_styles_filter( $css, $email ) {
 	return $css;
 }
 
-add_filter( 'woocommerce_email_styles', 'nsrwc_email_styles_filter', 10, 2 );
+add_filter( 'woocommerce_email_styles', 'nsrwc_email_styles_filter', 10, 1 );
 
 /**
  * Declare WooCommerce features compatibility to hide warnings.
@@ -164,7 +163,7 @@ add_filter( 'woocommerce_email_styles', 'nsrwc_email_styles_filter', 10, 2 );
  */
 function nsrwc_declare_features_compatibility() {
 	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
 	}
 }
 
@@ -195,10 +194,13 @@ function nsrwc_is_doing_email() {
  * @return bool
  */
 function nsrwc_is_doing_pdf() {
+	if ( ! wp_doing_ajax() || ! isset( $_GET['action'] ) ) {
+		return false;
+	}
+
 	if (
-		wp_doing_ajax() &&
-		isset( $_GET['action'] ) &&
-		'generate_wpo_wcpdf' === $_GET['action']
+		'generate_wpo_wcpdf' === $_GET['action'] ||
+		'wpifw_generate_invoice' === $_GET['action']
 	) {
 		return true;
 	}


### PR DESCRIPTION
Add compatibility with `Challan – PDF Invoice & Packing Slip for WooCommerce`
https://wordpress.org/plugins/webappick-pdf-invoice-for-woocommerce/
