### PR TITLE
fix: return default currency symbol for SEO and LLM crawlers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,9 @@ Adds support for the new Saudi Riyal symbol, UAE Dirham and Omani Rial symbols, 
 
 == Changelog ==
 
+= 2.1 =
+- Return the default WooCommerce currency symbol to SEO and LLM crawlers so prices stay machine-readable in structured data and AI search results.
+
 = 2.0 =
 - Added support for UAE Dirham (AED) and Omani Rial (OMR) symbols.
 - Better admin dashboard symbol rendering.

--- a/saudi-riyal-symbol-for-woocommerce.php
+++ b/saudi-riyal-symbol-for-woocommerce.php
@@ -224,6 +224,11 @@ function nsrwc_replace_gulf_currency_symbol( $currency_symbol, $currency ) {
 		return $currency_symbol;
 	}
 
+	// Bots: return WooCommerce's default symbol so crawlers can parse prices.
+	if ( nsrwc_is_seo_or_llm_bot() ) {
+		return $currency_symbol;
+	}
+
 	$config = NSRWC_GULF_CURRENCIES[ $currency ];
 
 	if ( nsrwc_is_doing_email() || nsrwc_is_doing_pdf() ) {
@@ -307,6 +312,62 @@ function nsrwc_is_doing_pdf() {
 	}
 
 	return false;
+}
+
+/**
+ * Detect SEO and LLM crawlers via the User-Agent header.
+ *
+ * The plugin's custom glyphs use new/PUA Unicode codepoints that crawlers
+ * (Googlebot, GPTBot, ClaudeBot, etc.) cannot render in text extraction,
+ * which breaks price parsing in structured data and page content. For these
+ * bots we fall back to WooCommerce's default symbol. Result is cached in a
+ * static so the User-Agent is parsed only once per request.
+ *
+ * @since 2.1
+ *
+ * @return bool
+ */
+function nsrwc_is_seo_or_llm_bot(): bool {
+	static $is_bot = null;
+
+	if ( null !== $is_bot ) {
+		return $is_bot;
+	}
+
+	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		return $is_bot = false;
+	}
+
+	$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+
+	$bot_tokens = array(
+		// SEO crawlers.
+		'Googlebot',
+		'Bingbot',
+		'Slurp',
+		'DuckDuckBot',
+		'Baiduspider',
+		'YandexBot',
+		// LLM / AI crawlers.
+		'GPTBot',
+		'ClaudeBot',
+		'PerplexityBot',
+		'Applebot',
+		'meta-externalagent',
+		'Bytespider',
+		'cohere-ai',
+		'anthropic-ai',
+	);
+
+	$is_bot = false;
+	foreach ( $bot_tokens as $token ) {
+		if ( false !== stripos( $user_agent, $token ) ) {
+			$is_bot = true;
+			break;
+		}
+	}
+
+	return $is_bot;
 }
 
 /**


### PR DESCRIPTION
## Summary

The plugin replaces the WooCommerce currency symbol for SAR, AED, and OMR with custom glyphs that use new/PUA Unicode codepoints. SEO and LLM crawlers (Googlebot, GPTBot, ClaudeBot, etc.) cannot render these codepoints during text extraction, which breaks price parsing in structured data and AI search results.

This change detects bot User-Agents and returns WooCommerce's default symbol for them, keeping prices machine-readable while preserving the custom glyph experience for regular visitors.

## Changes

- Add `nsrwc_is_seo_or_llm_bot()` helper that matches common SEO and LLM crawler tokens against `HTTP_USER_AGENT`, with per-request static caching.
- Short-circuit `nsrwc_replace_gulf_currency_symbol()` to return the default symbol when a bot is detected.
- Bump readme changelog to 2.1 with a user-facing note.

## Testing

1. Load a product page in a normal browser and confirm the custom Riyal/Dirham/Rial glyph still renders.
2. Reload the same page with a bot User-Agent, for example:
   `curl -A "Googlebot/2.1" https://example.com/?product=test`
3. Confirm the rendered HTML shows the default WooCommerce symbol (SAR, AED, OMR) instead of the custom glyph.
4. Repeat with `GPTBot`, `ClaudeBot`, `Bingbot` user agents and verify the same fallback.
5. Confirm emails and PDF invoices are unaffected (still use the existing fallback path).

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin now detects SEO and LLM crawlers and returns the default WooCommerce currency symbol for compatibility, ensuring prices remain machine-readable in structured data and AI search results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abdalsalaam/new-saudi-riyal-for-woocommerce/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->