### PR TITLE
Declare WooCommerce 10.8 and WordPress 7.0 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,7 @@ Adds support for the new Saudi Riyal symbol, UAE Dirham and Omani Rial symbols, 
 
 = 2.1 =
 - Return the default WooCommerce currency symbol to SEO and LLM crawlers so prices stay machine-readable in structured data and AI search results.
+- WordPress 7.0 and WooCommerce 10.8 compatibility.
 
 = 2.0 =
 - Added support for UAE Dirham (AED) and Omani Rial (OMR) symbols.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Author: abdalsalaam
 Author URI: https://halawa.io
 Tags: SAR, AED, OMR, symbol, saudi
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Requires Plugins: woocommerce
-WC tested up to: 10.4
+WC tested up to: 10.8
 Stable tag: 2.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/saudi-riyal-symbol-for-woocommerce.php
+++ b/saudi-riyal-symbol-for-woocommerce.php
@@ -8,10 +8,10 @@
  * Author URI: https://halawa.io
  * Text Domain: saudi-riyal-symbol-for-woocommerce
  * Domain Path: /languages
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * Requires PHP: 7.4
  * Requires Plugins: woocommerce
- * WC tested up to: 10.4
+ * WC tested up to: 10.8
  *
  * License: GNU General Public License v3.0
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Summary

Bumps the declared compatibility headers to WordPress 7.0 and WooCommerce 10.8, and adds a corresponding changelog entry.

## Changes

- Update "Tested up to" from 6.9 to 7.0 in `readme.txt` and the main plugin file.
- Update "WC tested up to" from 10.4 to 10.8 in `readme.txt` and the main plugin file.
- Add a 2.1 changelog entry noting the WordPress 7.0 and WooCommerce 10.8 compatibility.

## Testing

1. Activate the plugin on a site running WordPress 7.0 and WooCommerce 10.8.
2. Verify no compatibility warnings appear in the Plugins screen.
3. Confirm currency symbol output still renders correctly for SAR, AED, and OMR on the storefront and in the admin.