### PR TITLE
Keep the currency glyph out of machine-readable output (v2.3)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,12 @@
+/**
+ * Gulf currency glyphs.
+ *
+ * The `unicode-range` descriptor is what makes this safe to apply broadly: the
+ * browser pulls the webfont in only for the Gulf codepoints and leaves every
+ * other character — digits, Arabic text, other currency symbols — to the next
+ * font in the stack. It also means the font file is never downloaded on a page
+ * that has no Gulf price on it.
+ */
 @font-face {
     font-family: 'gulf-currencies';
     src: url('../fonts/gulf-currencies.eot');
@@ -8,26 +17,56 @@
     font-weight: normal;
     font-style: normal;
     font-display: block;
-    unicode-range: U+E001, U+E002, U+20C1, U+E900;
+    unicode-range: U+20C1, U+E001, U+E002, U+E900;
 }
 
-/* Generic class for elements containing Gulf currency symbols */
+/*
+ * WooCommerce already wraps the symbol in .woocommerce-Price-currencySymbol, so
+ * most prices need no JavaScript at all. The JS-applied classes cover the places
+ * that render a price without that wrapper (Cart/Checkout blocks, React admin).
+ *
+ * The fallback stack matters because the JS marks the *parent* of the matched
+ * text node, which often also holds the digits.
+ */
+.woocommerce-Price-currencySymbol,
 .gulf-currency,
+.nsrwc-symbol,
 /* Backward compatibility with old class name */
-.sar-currency-symbol{
-    font-family: 'gulf-currencies', serif !important;
+.sar-currency-symbol {
+    font-family: 'gulf-currencies', var(--nsrwc-font-stack, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif) !important;
     speak: never;
     font-style: normal;
-    font-weight: normal;
+    font-weight: inherit;
     font-variant: normal;
     text-transform: none;
-    line-height: 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
 
+/*
+ * Separates the glyph from the amount. Before 2.3 this was done by forcing
+ * WooCommerce's currency position option to "left_space", which overrode the
+ * merchant's own setting and corrupted product feeds that parse the rendered
+ * price format. Doing it in CSS keeps the store setting intact.
+ *
+ * The side depends on the store's currency position, which is published as a
+ * body class: the amount is a bare text node, so a selector like :last-child
+ * cannot tell whether the symbol comes before or after it.
+ * The *_space positions already emit a real space, so they get no margin.
+ */
+.nsrwc-pos-left .woocommerce-Price-currencySymbol,
+.nsrwc-pos-left .gulf-currency,
+.nsrwc-pos-left .nsrwc-symbol {
+    margin-inline-end: 0.15em;
+}
+
+.nsrwc-pos-right .woocommerce-Price-currencySymbol,
+.nsrwc-pos-right .gulf-currency,
+.nsrwc-pos-right .nsrwc-symbol {
+    margin-inline-start: 0.15em;
+}
 
 /* WooCommerce Admin Dashboard */
-.gulf-currency-dashboard{
-    font-family: 'gulf-currencies', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !important;
+.gulf-currency-dashboard {
+    font-family: 'gulf-currencies', var(--nsrwc-font-stack, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif) !important;
 }

--- a/assets/js/gulf-currencies.js
+++ b/assets/js/gulf-currencies.js
@@ -1,8 +1,17 @@
 /**
  * Gulf Currencies Symbol Fix for WooCommerce.
  *
- * Adds 'gulf-currency' class to the direct parent element of Gulf currency symbols
- * to enable proper font rendering.
+ * WooCommerce's classic templates wrap the symbol in
+ * .woocommerce-Price-currencySymbol, which the stylesheet targets directly.
+ * The Cart/Checkout blocks and the React admin screens render a price as one
+ * flat text node instead, so there is nothing to target. This script finds
+ * those nodes and tags their parent.
+ *
+ * Because that parent usually holds the digits too, tagging it must not throw
+ * away the theme's font. The element's own resolved stack is captured into a
+ * custom property first, and the stylesheet prepends the glyph font to it — so
+ * only the Gulf codepoints (see the @font-face unicode-range) come from the
+ * bundled font and everything else keeps rendering exactly as the theme meant.
  */
 ( function() {
 	'use strict';
@@ -24,16 +33,30 @@
 
 	// Debounce state
 	let pending = [];
-	let rafId = null;
+	let scheduled = false;
 
 	/**
-	 * Mark element with currency class.
+	 * Mark element with currency class, preserving its inherited font stack.
 	 */
 	function markElement( el ) {
-		if ( el && el.classList && ! processed.has( el ) ) {
-			el.classList.add( currencyClass );
-			processed.add( el );
+		if ( ! el || ! el.classList || processed.has( el ) ) {
+			return;
 		}
+
+		// Capture the stack the element already resolves to, before our class
+		// lands, so non-Gulf characters in the same element are untouched.
+		try {
+			const inherited = window.getComputedStyle( el ).fontFamily;
+			if ( inherited && inherited.indexOf( 'gulf-currencies' ) === -1 ) {
+				el.style.setProperty( '--nsrwc-font-stack', inherited );
+			}
+		} catch ( e ) {
+			// getComputedStyle can throw on detached nodes; the stylesheet's
+			// own fallback stack covers that case.
+		}
+
+		el.classList.add( currencyClass );
+		processed.add( el );
 	}
 
 	/**
@@ -57,10 +80,10 @@
 	}
 
 	/**
-	 * Process pending nodes in batched animation frame.
+	 * Process pending nodes in a batch.
 	 */
 	function flushPending() {
-		rafId = null;
+		scheduled = false;
 		const nodes = pending;
 		pending = [];
 
@@ -76,11 +99,21 @@
 
 	/**
 	 * Schedule pending nodes processing.
+	 *
+	 * requestAnimationFrame is throttled to a standstill in background tabs, so
+	 * a timeout runs alongside it: whichever fires first does the work, and
+	 * flushPending is idempotent.
 	 */
 	function schedulePending() {
-		if ( ! rafId ) {
-			rafId = requestAnimationFrame( flushPending );
+		if ( scheduled ) {
+			return;
 		}
+		scheduled = true;
+
+		if ( typeof window.requestAnimationFrame === 'function' ) {
+			window.requestAnimationFrame( flushPending );
+		}
+		window.setTimeout( flushPending, 50 );
 	}
 
 	/**

--- a/includes/class-nsrwc-admin-notices.php
+++ b/includes/class-nsrwc-admin-notices.php
@@ -129,7 +129,7 @@ class NSRWC_Admin_Notices {
 		}
 
 		wp_send_json_success( array( 'message' => 'Notice dismissed' ) );
-    }
+	}
 
 	/**
 	 * Enqueue admin scripts for notice dismissal.
@@ -151,7 +151,7 @@ class NSRWC_Admin_Notices {
 
 		wp_enqueue_script(
 			'nsrwc-admin-notice',
-			plugins_url( 'assets/js/admin-notice.js', dirname( __FILE__ ) ),
+			plugins_url( 'assets/js/admin-notice.js', __DIR__ ),
 			array( 'jquery' ),
 			NSRWC_VERSION,
 			true

--- a/includes/class-nsrwc-admin-notices.php
+++ b/includes/class-nsrwc-admin-notices.php
@@ -17,6 +17,41 @@ if ( ! defined( 'ABSPATH' ) ) {
 class NSRWC_Admin_Notices {
 
 	/**
+	 * Prefix for the per-user dismissal meta keys.
+	 *
+	 * Bumping this suffix re-shows the notice to every user, including those who
+	 * had dismissed the previous one, without touching their old meta. Keep the
+	 * suffix in step with the release that changes the notice copy.
+	 *
+	 * @since 2.3
+	 *
+	 * @var string
+	 */
+	const DISMISS_META_PREFIX = 'nsrwc_notice_2_3';
+
+	/**
+	 * Meta key holding the permanent dismissal flag.
+	 *
+	 * @since 2.3
+	 *
+	 * @return string
+	 */
+	private static function permanent_dismiss_key(): string {
+		return self::DISMISS_META_PREFIX . '_permanently_dismissed';
+	}
+
+	/**
+	 * Meta key holding the timestamp of the first dismissal.
+	 *
+	 * @since 2.3
+	 *
+	 * @return string
+	 */
+	private static function first_dismiss_key(): string {
+		return self::DISMISS_META_PREFIX . '_first_dismiss_time';
+	}
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -42,11 +77,11 @@ class NSRWC_Admin_Notices {
 
 		$user_id = get_current_user_id();
 
-		if ( get_user_meta( $user_id, 'nsrwc_notice_permanently_dismissed', true ) ) {
+		if ( get_user_meta( $user_id, self::permanent_dismiss_key(), true ) ) {
 			return false;
 		}
 
-		$first_dismiss_time = get_user_meta( $user_id, 'nsrwc_notice_first_dismiss_time', true );
+		$first_dismiss_time = get_user_meta( $user_id, self::first_dismiss_key(), true );
 		if ( $first_dismiss_time ) {
 			$days_since_dismiss = ( time() - $first_dismiss_time ) / DAY_IN_SECONDS;
 			if ( $days_since_dismiss < 7 ) {
@@ -120,12 +155,12 @@ class NSRWC_Admin_Notices {
 		}
 
 		$user_id            = get_current_user_id();
-		$first_dismiss_time = get_user_meta( $user_id, 'nsrwc_notice_first_dismiss_time', true );
+		$first_dismiss_time = get_user_meta( $user_id, self::first_dismiss_key(), true );
 
 		if ( ! $first_dismiss_time ) {
-			update_user_meta( $user_id, 'nsrwc_notice_first_dismiss_time', time() );
+			update_user_meta( $user_id, self::first_dismiss_key(), time() );
 		} else {
-			update_user_meta( $user_id, 'nsrwc_notice_permanently_dismissed', true );
+			update_user_meta( $user_id, self::permanent_dismiss_key(), true );
 		}
 
 		wp_send_json_success( array( 'message' => 'Notice dismissed' ) );
@@ -141,7 +176,7 @@ class NSRWC_Admin_Notices {
 			return;
 		}
 
-		if ( get_user_meta( get_current_user_id(), 'nsrwc_notice_permanently_dismissed', true ) ) {
+		if ( get_user_meta( get_current_user_id(), self::permanent_dismiss_key(), true ) ) {
 			return;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ For more details about the Saudi Riyal symbol, please refer to the [Saudi Centra
 ## Features
 - Supports Saudi Riyal (SAR), UAE Dirham (AED), and Omani Rial (OMR) symbols.
 - Displays the currency symbols on the front-end, admin dashboard, WooCommerce emails, and PDF invoices.
-- Supports RTL environments by forcing the symbol to appear on the left.
+- Supports RTL environments, and respects the store's own WooCommerce "Currency position" setting.
 - Supports block-based themes (Cart/Checkout blocks).
 - Compatible with popular currency switcher plugins (WOOCS, Multi Currency for WooCommerce, and more).
 
@@ -39,6 +39,13 @@ For more details about the Saudi Riyal symbol, please refer to the [Saudi Centra
 - WooCommerce Multi-Currency
 
 ## Changelog
+
+### 2.3
+- Fixed the currency symbol corrupting product feeds, REST API responses and other machine-readable output, and stopped overriding the store's "Currency position" setting (stores that chose "right" will now see the symbol move there).
+- Fixed the email symbol image leaking into later prices, a possible crash with multi-currency plugins, empty boxes on non-Gulf stores, and other plugins no longer being able to override the symbol.
+
+### 2.2
+- WordPress 7.1 and WooCommerce 11.1 compatibility.
 
 ### 2.1
 - WordPress 7.0 and WooCommerce 10.8 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -39,21 +39,8 @@ Adds support for the new Saudi Riyal symbol, UAE Dirham and Omani Rial symbols, 
 == Changelog ==
 
 = 2.3 =
-Compatibility release. The currency symbol is no longer allowed to reach systems that read prices as data.
-
-- Fixed product feeds (Google Shopping / Merchant Center, Facebook, TikTok, Pinterest and other feed plugins) receiving the currency symbol where the price should be. The plugin used to force WooCommerce's currency position to "left with space", which changed the rendered price markup that feed plugins parse.
-- Stopped overriding the store's "Currency position" setting. The setting is now honoured as the merchant configured it, and the spacing around the symbol is applied with CSS instead. **If you had set the position to "right" or "right with space", the symbol will now actually move to the right** - previous versions forced it to the left regardless. Stores on the default setting look the same as before.
-- The symbol is no longer replaced in machine-readable output: the REST API, WP-CLI, cron, XML-RPC and feeds now always receive WooCommerce's standard symbol. The Cart/Checkout blocks (Store API) still get the new symbol.
-- Fixed the email/PDF image fallback leaking into every price rendered later in the same request, including REST API responses and product feeds.
-- The plain-text part of order emails no longer receives an HTML image tag in place of the symbol.
-- Fixed a potential infinite recursion (and white screen) with multi-currency plugins that read the currency position while resolving the active currency.
-- The symbol is now emitted as a real character instead of an HTML entity, so plugins that treat it as plain text no longer show a literal "&#x20c1;".
-- Lowered the filter priority so other plugins and site snippets can override the symbol again, and added `nsrwc_render_glyph`, `nsrwc_load_assets` and `nsrwc_reset_currency_cache()` for integrations.
-- Fixed Gulf symbols being substituted on stores whose currency is not a Gulf currency, where the webfont is not loaded and shoppers saw empty boxes.
-- Prices in the Cart/Checkout blocks and the admin now keep the theme's font for the digits; only the currency glyph uses the bundled font.
-- Much less work per rendered price: the active currency is resolved once per request instead of on every price.
-- Added more SEO, AI and ad-platform crawlers to the list that receives the standard symbol.
-- WordPress 7.1 and WooCommerce 11.1 compatibility.
+- Fixed the currency symbol corrupting product feeds, REST API responses and other machine-readable output, and stopped overriding the store's "Currency position" setting (stores that chose "right" will now see the symbol move there).
+- Fixed the email symbol image leaking into later prices, a possible crash with multi-currency plugins, empty boxes on non-Gulf stores, and other plugins no longer being able to override the symbol.
 
 = 2.2 =
 - WordPress 7.1 and WooCommerce 11.1 compatibility.
@@ -104,4 +91,4 @@ Compatibility release. The currency symbol is no longer allowed to reach systems
 == Upgrade Notice ==
 
 = 2.3 =
-Fixes the currency symbol corrupting product feeds, REST API responses and other machine-readable output. One visible change: the store's own "Currency position" setting is now respected instead of being forced to "left with space", so stores that had chosen "right" will see the symbol move to where they configured it.
+Fixes the currency symbol corrupting product feeds and REST API output. The store's own "Currency position" setting is now respected instead of being forced to "left with space".

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,12 @@
 Author: abdalsalaam
 Author URI: https://halawa.io
 Tags: SAR, AED, OMR, symbol, saudi
+Requires at least: 6.5
 Tested up to: 7.1
 Requires PHP: 7.4
 Requires Plugins: woocommerce
 WC tested up to: 11.1
-Stable tag: 2.2
+Stable tag: 2.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -36,6 +37,23 @@ Adds support for the new Saudi Riyal symbol, UAE Dirham and Omani Rial symbols, 
 - WooCommerce Multi-Currency
 
 == Changelog ==
+
+= 2.3 =
+Compatibility release. The currency symbol is no longer allowed to reach systems that read prices as data.
+
+- Fixed product feeds (Google Shopping / Merchant Center, Facebook, TikTok, Pinterest and other feed plugins) receiving the currency symbol where the price should be. The plugin used to force WooCommerce's currency position to "left with space", which changed the rendered price markup that feed plugins parse.
+- Stopped overriding the store's "Currency position" setting. The setting is now honoured as the merchant configured it, and the spacing around the symbol is applied with CSS instead.
+- The symbol is no longer replaced in machine-readable output: the REST API, WP-CLI, cron, XML-RPC and feeds now always receive WooCommerce's standard symbol. The Cart/Checkout blocks (Store API) still get the new symbol.
+- Fixed the email/PDF image fallback leaking into every price rendered later in the same request, including REST API responses and product feeds.
+- The plain-text part of order emails no longer receives an HTML image tag in place of the symbol.
+- Fixed a potential infinite recursion (and white screen) with multi-currency plugins that read the currency position while resolving the active currency.
+- The symbol is now emitted as a real character instead of an HTML entity, so plugins that treat it as plain text no longer show a literal "&#x20c1;".
+- Lowered the filter priority so other plugins and site snippets can override the symbol again, and added `nsrwc_render_glyph`, `nsrwc_load_assets` and `nsrwc_reset_currency_cache()` for integrations.
+- Fixed Gulf symbols being substituted on stores whose currency is not a Gulf currency, where the webfont is not loaded and shoppers saw empty boxes.
+- Prices in the Cart/Checkout blocks and the admin now keep the theme's font for the digits; only the currency glyph uses the bundled font.
+- Much less work per rendered price: the active currency is resolved once per request instead of on every price.
+- Added more SEO, AI and ad-platform crawlers to the list that receives the standard symbol.
+- WordPress 7.1 and WooCommerce 11.1 compatibility.
 
 = 2.2 =
 - WordPress 7.1 and WooCommerce 11.1 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Author: abdalsalaam
 Author URI: https://halawa.io
 Tags: SAR, AED, OMR, symbol, saudi
-Requires at least: 6.5
+Requires at least: 6.3
 Tested up to: 7.1
 Requires PHP: 7.4
 Requires Plugins: woocommerce
@@ -42,7 +42,7 @@ Adds support for the new Saudi Riyal symbol, UAE Dirham and Omani Rial symbols, 
 Compatibility release. The currency symbol is no longer allowed to reach systems that read prices as data.
 
 - Fixed product feeds (Google Shopping / Merchant Center, Facebook, TikTok, Pinterest and other feed plugins) receiving the currency symbol where the price should be. The plugin used to force WooCommerce's currency position to "left with space", which changed the rendered price markup that feed plugins parse.
-- Stopped overriding the store's "Currency position" setting. The setting is now honoured as the merchant configured it, and the spacing around the symbol is applied with CSS instead.
+- Stopped overriding the store's "Currency position" setting. The setting is now honoured as the merchant configured it, and the spacing around the symbol is applied with CSS instead. **If you had set the position to "right" or "right with space", the symbol will now actually move to the right** - previous versions forced it to the left regardless. Stores on the default setting look the same as before.
 - The symbol is no longer replaced in machine-readable output: the REST API, WP-CLI, cron, XML-RPC and feeds now always receive WooCommerce's standard symbol. The Cart/Checkout blocks (Store API) still get the new symbol.
 - Fixed the email/PDF image fallback leaking into every price rendered later in the same request, including REST API responses and product feeds.
 - The plain-text part of order emails no longer receives an HTML image tag in place of the symbol.
@@ -101,3 +101,7 @@ Compatibility release. The currency symbol is no longer allowed to reach systems
 = 1.0 =
 - Initial release.
 
+== Upgrade Notice ==
+
+= 2.3 =
+Fixes the currency symbol corrupting product feeds, REST API responses and other machine-readable output. One visible change: the store's own "Currency position" setting is now respected instead of being forced to "left with space", so stores that had chosen "right" will see the symbol move to where they configured it.

--- a/saudi-riyal-symbol-for-woocommerce.php
+++ b/saudi-riyal-symbol-for-woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://halawa.io
  * Text Domain: saudi-riyal-symbol-for-woocommerce
  * Domain Path: /languages
- * Requires at least: 6.5
+ * Requires at least: 6.3
  * Tested up to: 7.1
  * Requires PHP: 7.4
  * Requires Plugins: woocommerce
@@ -42,6 +42,8 @@ const NSRWC_VERSION = '2.3';
 /**
  * Gulf currencies configuration.
  *
+ * `unicode`  Retained as an alias of `char` in HTML-entity form: it was part of
+ *            this public constant before 2.3 and third-party snippets read it.
  * `char`     The glyph we render for display. SAR uses U+20C1 SAUDI RIYAL SIGN, the
  *            codepoint officially assigned by Unicode. AED and OMR have no assigned
  *            codepoint yet, so they use Private Use Area codepoints that only resolve
@@ -54,16 +56,19 @@ const NSRWC_VERSION = '2.3';
  */
 const NSRWC_GULF_CURRENCIES = array(
 	'SAR' => array(
-		'char' => "\u{20C1}",
-		'png'  => 'SAR.png',
+		'char'    => "\u{20C1}",
+		'unicode' => '&#x20c1;',
+		'png'     => 'SAR.png',
 	),
 	'AED' => array(
-		'char' => "\u{E001}",
-		'png'  => 'AED.png',
+		'char'    => "\u{E001}",
+		'unicode' => '&#xe001;',
+		'png'     => 'AED.png',
 	),
 	'OMR' => array(
-		'char' => "\u{E900}",
-		'png'  => 'OMR.png',
+		'char'    => "\u{E900}",
+		'unicode' => '&#xe900;',
+		'png'     => 'OMR.png',
 	),
 );
 
@@ -257,6 +262,11 @@ function nsrwc_should_render_glyph( $currency ) {
 	} elseif ( ! nsrwc_should_load_assets() ) {
 		// The webfont is not loaded on this request, so the glyph would be tofu.
 		$render = false;
+	} elseif ( nsrwc_is_doing_email() || nsrwc_is_doing_pdf() ) {
+		// An email or invoice is read by a person no matter what triggered it, so
+		// it keeps the symbol even when the request itself is cron or WP-CLI —
+		// otherwise the same email looks different depending on how it was sent.
+		$render = true;
 	} elseif ( nsrwc_is_machine_context() ) {
 		$render = false;
 	} elseif ( nsrwc_is_seo_or_llm_bot() ) {
@@ -375,19 +385,37 @@ add_filter( 'admin_body_class', 'nsrwc_body_class' );
 /**
  * Adjust currency format for PDF contexts.
  *
- * @param string $format Price format string.
+ * @param string $format       Price format string.
+ * @param string $currency_pos Configured currency position.
  *
  * @return string
  */
-function nsrwc_wrap_currency_symbol( $format ) {
+function nsrwc_wrap_currency_symbol( $format, $currency_pos = '' ) {
 	if ( nsrwc_is_doing_pdf() && class_exists( 'WCPDF_Custom_PDF_Maker_mPDF' ) ) {
 		return '%2$s&nbsp;%1$s';
+	}
+
+	// On the site the gap between glyph and amount comes from the stylesheet, but
+	// email and PDF never load it, so there the space goes back into the format.
+	// Scoped to those two contexts so the markup product feeds parse is untouched.
+	if ( nsrwc_is_doing_email() || nsrwc_is_doing_pdf() ) {
+		$currency = nsrwc_get_current_gulf_currency();
+
+		if ( is_string( $currency ) && nsrwc_should_render_glyph( $currency ) ) {
+			if ( 'left' === $currency_pos ) {
+				return '%1$s&nbsp;%2$s';
+			}
+
+			if ( 'right' === $currency_pos ) {
+				return '%2$s&nbsp;%1$s';
+			}
+		}
 	}
 
 	return $format;
 }
 
-add_filter( 'woocommerce_price_format', 'nsrwc_wrap_currency_symbol', 9999, 1 );
+add_filter( 'woocommerce_price_format', 'nsrwc_wrap_currency_symbol', 9999, 2 );
 
 /**
  * Replace Gulf currency symbols with custom font glyphs.

--- a/saudi-riyal-symbol-for-woocommerce.php
+++ b/saudi-riyal-symbol-for-woocommerce.php
@@ -3,29 +3,33 @@
  * Plugin Name: Gulf currencies Symbols for WooCommerce - رمز الريال السعودي والدرهم الإماراتي
  * Plugin URI: https://wordpress.org/plugins/saudi-riyal-symbol-for-woocommerce
  * Description: Adds support for the new Saudi Riyal symbol, UAE Dirham and Omani Rial symbols, in WooCommerce.
- * Version: 2.2
+ * Version: 2.3
  * Author: Abdalsalaam Halawa
  * Author URI: https://halawa.io
  * Text Domain: saudi-riyal-symbol-for-woocommerce
  * Domain Path: /languages
+ * Requires at least: 6.5
  * Tested up to: 7.1
  * Requires PHP: 7.4
  * Requires Plugins: woocommerce
+ * WC requires at least: 8.0
  * WC tested up to: 11.1
  *
  * License: GNU General Public License v3.0
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * @package Saudi_Riyal_Symbol_for_WooCommerce
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$WC_plugin_path = trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/woocommerce.php';
+$nsrwc_wc_plugin_path = trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/woocommerce.php';
 
 if (
-	! in_array( $WC_plugin_path, wp_get_active_and_valid_plugins() )
-	&& ! in_array( $WC_plugin_path, wp_get_active_network_plugins() )
+	! in_array( $nsrwc_wc_plugin_path, wp_get_active_and_valid_plugins(), true )
+	&& ! in_array( $nsrwc_wc_plugin_path, wp_get_active_network_plugins(), true )
 ) {
 	return;
 }
@@ -33,23 +37,33 @@ if (
 /**
  * Plugin version.
  */
-const NSRWC_VERSION = '2.2';
+const NSRWC_VERSION = '2.3';
 
 /**
- * Gulf currencies configuration with unicode mappings.
+ * Gulf currencies configuration.
+ *
+ * `char`     The glyph we render for display. SAR uses U+20C1 SAUDI RIYAL SIGN, the
+ *            codepoint officially assigned by Unicode. AED and OMR have no assigned
+ *            codepoint yet, so they use Private Use Area codepoints that only resolve
+ *            against the bundled webfont — which is exactly why they must never reach
+ *            feeds, APIs or any other machine-readable output.
+ * `png`      Raster fallback for email and PDF, where webfonts are unreliable.
+ *
+ * @since 2.3 `char` replaces the previous HTML-entity form; entities leaked verbatim
+ *            into consumers that treat the symbol as plain text.
  */
 const NSRWC_GULF_CURRENCIES = array(
 	'SAR' => array(
-		'unicode' => '&#x20c1;',
-		'png'     => 'SAR.png',
+		'char' => "\u{20C1}",
+		'png'  => 'SAR.png',
 	),
 	'AED' => array(
-		'unicode' => '&#xe001;',
-		'png'     => 'AED.png',
+		'char' => "\u{E001}",
+		'png'  => 'AED.png',
 	),
 	'OMR' => array(
-		'unicode' => '&#xe900;',
-		'png'     => 'OMR.png',
+		'char' => "\u{E900}",
+		'png'  => 'OMR.png',
 	),
 );
 
@@ -71,43 +85,73 @@ add_action( 'plugins_loaded', 'nsrwc_load_textdomain' );
 /**
  * Get the current active Gulf currency code if applicable.
  *
+ * Resolving the active currency is surprisingly expensive once a multi-currency
+ * plugin is installed, and WooCommerce asks for the symbol once per rendered
+ * price. The result is memoised per request; multi-currency plugins that switch
+ * currency mid-request can clear it with `nsrwc_reset_currency_cache()`.
+ *
  * @return string|false Currency code (SAR, AED, OMR) or false if not a Gulf currency.
  */
 function nsrwc_get_current_gulf_currency() {
+	if ( isset( $GLOBALS['nsrwc_currency_cache'] ) ) {
+		return $GLOBALS['nsrwc_currency_cache'];
+	}
+
+	$resolved        = false;
 	$gulf_currencies = array_keys( NSRWC_GULF_CURRENCIES );
 
 	// Check default WooCommerce currency.
 	$wc_currency = get_woocommerce_currency();
 	if ( in_array( $wc_currency, $gulf_currencies, true ) ) {
-		return $wc_currency;
+		$resolved = $wc_currency;
 	}
 
 	// Support for WOOCS - WooCommerce Currency Switcher.
-	if ( class_exists( 'WOOCS' ) ) {
+	if ( false === $resolved && class_exists( 'WOOCS' ) ) {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Global owned by the WOOCS plugin.
 		global $WOOCS;
-		if ( $WOOCS && in_array( $WOOCS->current_currency, $gulf_currencies, true ) ) {
-			return $WOOCS->current_currency;
+		if ( $WOOCS && ! empty( $WOOCS->current_currency ) && in_array( $WOOCS->current_currency, $gulf_currencies, true ) ) {
+			$resolved = $WOOCS->current_currency;
 		}
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
 	// Support for Multi Currency for WooCommerce by VillaTheme.
-	if ( function_exists( 'wmc_get_current_currency' ) ) {
+	if ( false === $resolved && function_exists( 'wmc_get_current_currency' ) ) {
 		$current = wmc_get_current_currency();
 		if ( in_array( $current, $gulf_currencies, true ) ) {
-			return $current;
+			$resolved = $current;
 		}
 	}
 
 	// Support for WooCommerce Multi-Currency.
-	if ( class_exists( 'WOOMC\Model\Currency' ) ) {
+	if ( false === $resolved && class_exists( 'WOOMC\\Model\\Currency' ) ) {
 		$current_currency = apply_filters( 'woocommerce_currency', get_woocommerce_currency() );
 		if ( in_array( $current_currency, $gulf_currencies, true ) ) {
-			return $current_currency;
+			$resolved = $current_currency;
 		}
 	}
 
-	return false;
+	$GLOBALS['nsrwc_currency_cache'] = $resolved;
+
+	return $resolved;
 }
+
+/**
+ * Clear the memoised active-currency lookup.
+ *
+ * Multi-currency plugins that switch currency part-way through a request should
+ * call this so the next rendered price picks up the new currency.
+ *
+ * @since 2.3
+ *
+ * @return void
+ */
+function nsrwc_reset_currency_cache() {
+	unset( $GLOBALS['nsrwc_currency_cache'] );
+}
+
+add_action( 'woocommerce_currency_changed', 'nsrwc_reset_currency_cache' );
 
 /**
  * Check if the current currency is a supported Gulf currency.
@@ -119,12 +163,127 @@ function nsrwc_is_gulf_currency() {
 }
 
 /**
+ * Whether the plugin's presentation assets apply to this request.
+ *
+ * The custom glyphs only resolve against the bundled webfont, so they must not be
+ * emitted on requests where that stylesheet is never loaded — otherwise shoppers
+ * get tofu boxes. Multi-currency stores whose base currency is not a Gulf currency
+ * can force this on with the `nsrwc_load_assets` filter.
+ *
+ * @since 2.3
+ *
+ * @return bool
+ */
+function nsrwc_should_load_assets() {
+	return (bool) apply_filters( 'nsrwc_load_assets', nsrwc_is_gulf_currency() );
+}
+
+/**
+ * Whether the request is being served to a machine rather than a browser.
+ *
+ * REST (other than the Store API, which drives the Cart/Checkout blocks), WP-CLI,
+ * cron, XML-RPC and feeds all produce output that some other system parses. The
+ * custom glyphs are meaningless there — AED and OMR in particular are Private Use
+ * Area codepoints — so those contexts always get WooCommerce's own symbol.
+ *
+ * @since 2.3
+ *
+ * @return bool
+ */
+function nsrwc_is_machine_context() {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+
+	if ( function_exists( 'wp_doing_cron' ) ? wp_doing_cron() : ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
+		return true;
+	}
+
+	if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+		return true;
+	}
+
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST && ! nsrwc_is_store_api_request() ) {
+		return true;
+	}
+
+	if ( did_action( 'parse_query' ) && is_feed() ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Whether the current REST request targets the WooCommerce Store API.
+ *
+ * The Store API is the data source for the Cart and Checkout blocks, so its
+ * responses are rendered to a shopper and should carry the glyph. Every other
+ * REST namespace is treated as machine output.
+ *
+ * @since 2.3
+ *
+ * @return bool
+ */
+function nsrwc_is_store_api_request() {
+	$route = '';
+
+	if ( ! empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+		$route = (string) $GLOBALS['wp']->query_vars['rest_route'];
+	} elseif ( isset( $_SERVER['REQUEST_URI'] ) ) {
+		$route = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+	}
+
+	return false !== strpos( $route, '/wc/store/' );
+}
+
+/**
+ * Whether the custom glyph should be rendered for this currency, right now.
+ *
+ * This is the single gate every symbol replacement passes through. Third-party
+ * code can opt a context out entirely with the `nsrwc_render_glyph` filter.
+ *
+ * @since 2.3
+ *
+ * @param string $currency Currency code being rendered.
+ *
+ * @return bool
+ */
+function nsrwc_should_render_glyph( $currency ) {
+	$render = true;
+
+	if ( ! isset( NSRWC_GULF_CURRENCIES[ $currency ] ) ) {
+		$render = false;
+	} elseif ( ! nsrwc_should_load_assets() ) {
+		// The webfont is not loaded on this request, so the glyph would be tofu.
+		$render = false;
+	} elseif ( nsrwc_is_machine_context() ) {
+		$render = false;
+	} elseif ( nsrwc_is_seo_or_llm_bot() ) {
+		$render = false;
+	}
+
+	/**
+	 * Filters whether the Gulf currency glyph is rendered.
+	 *
+	 * Return false to make the plugin fall back to WooCommerce's own symbol, for
+	 * example inside a product feed, an export, or a payment gateway payload.
+	 *
+	 * @since 2.3
+	 *
+	 * @param bool   $render   Whether to render the glyph.
+	 * @param string $currency Currency code.
+	 */
+	return (bool) apply_filters( 'nsrwc_render_glyph', $render, $currency );
+}
+
+/**
  * Enqueue front-end CSS if currency is a Gulf currency.
  *
  * @return void
  */
 function nsrwc_enqueue_font_css() {
-	if ( ! nsrwc_is_gulf_currency() ) {
+	if ( ! nsrwc_should_load_assets() ) {
 		return;
 	}
 
@@ -145,11 +304,11 @@ add_action( 'admin_enqueue_scripts', 'nsrwc_enqueue_font_css' );
  * @return void
  */
 function nsrwc_enqueue_frontend_scripts() {
-	$current_currency = nsrwc_get_current_gulf_currency();
-
-	if ( ! $current_currency ) {
+	if ( ! nsrwc_should_load_assets() ) {
 		return;
 	}
+
+	$current_currency = nsrwc_get_current_gulf_currency();
 
 	wp_enqueue_script(
 		'gulf-currencies-blocks-fix',
@@ -159,10 +318,13 @@ function nsrwc_enqueue_frontend_scripts() {
 		array( 'in_footer' => true )
 	);
 
-	// Pass currency unicode symbols to JavaScript for detection.
-	$currency_symbols = array_map( function ( $config ) {
-		return html_entity_decode( $config['unicode'], ENT_HTML5, 'UTF-8' );
-	}, NSRWC_GULF_CURRENCIES );
+	// Pass currency glyphs to JavaScript for detection.
+	$currency_symbols = array_map(
+		static function ( $config ) {
+			return $config['char'];
+		},
+		NSRWC_GULF_CURRENCIES
+	);
 
 	wp_localize_script(
 		'gulf-currencies-blocks-fix',
@@ -178,21 +340,37 @@ add_action( 'wp_enqueue_scripts', 'nsrwc_enqueue_frontend_scripts' );
 add_action( 'admin_enqueue_scripts', 'nsrwc_enqueue_frontend_scripts' );
 
 /**
- * Force currency position : "left with space" for Gulf currencies.
+ * Flag the document so the stylesheet can scope the symbol spacing.
  *
- * @param string $option Current position.
+ * @since 2.3
  *
- * @return string
+ * @param array|string $classes Existing body classes.
+ *
+ * @return array|string
  */
-function nsrwc_woocommerce_currency_pos( $option ) {
-	if ( nsrwc_is_gulf_currency() ) {
-		return 'left_space';
+function nsrwc_body_class( $classes ) {
+	if ( ! nsrwc_should_load_assets() ) {
+		return $classes;
 	}
 
-	return $option;
+	// The position class lets the stylesheet put the spacing on the correct side
+	// without guessing from the DOM: the amount is a bare text node, so CSS alone
+	// cannot tell whether the symbol precedes or follows it.
+	$position = get_option( 'woocommerce_currency_pos', 'left' );
+	$added    = 'nsrwc-gulf-currency nsrwc-pos-' . sanitize_html_class( (string) $position );
+
+	if ( is_array( $classes ) ) {
+		foreach ( explode( ' ', $added ) as $class ) {
+			$classes[] = $class;
+		}
+		return $classes;
+	}
+
+	return trim( $classes . ' ' . $added );
 }
 
-add_filter( 'option_woocommerce_currency_pos', 'nsrwc_woocommerce_currency_pos', 9999 );
+add_filter( 'body_class', 'nsrwc_body_class' );
+add_filter( 'admin_body_class', 'nsrwc_body_class' );
 
 /**
  * Adjust currency format for PDF contexts.
@@ -212,7 +390,10 @@ function nsrwc_wrap_currency_symbol( $format ) {
 add_filter( 'woocommerce_price_format', 'nsrwc_wrap_currency_symbol', 9999, 1 );
 
 /**
- * Replace Gulf currency symbols with custom font icons.
+ * Replace Gulf currency symbols with custom font glyphs.
+ *
+ * Returns a plain string in every case — never HTML — outside of email and PDF
+ * rendering, where a raster image is the only thing that renders reliably.
  *
  * @param string $currency_symbol Original currency symbol.
  * @param string $currency        Currency code.
@@ -220,25 +401,25 @@ add_filter( 'woocommerce_price_format', 'nsrwc_wrap_currency_symbol', 9999, 1 );
  * @return string
  */
 function nsrwc_replace_gulf_currency_symbol( $currency_symbol, $currency ) {
-	if ( ! isset( NSRWC_GULF_CURRENCIES[ $currency ] ) ) {
-		return $currency_symbol;
-	}
-
-	// Bots: return WooCommerce's default symbol so crawlers can parse prices.
-	if ( nsrwc_is_seo_or_llm_bot() ) {
+	if ( ! nsrwc_should_render_glyph( $currency ) ) {
 		return $currency_symbol;
 	}
 
 	$config = NSRWC_GULF_CURRENCIES[ $currency ];
 
 	if ( nsrwc_is_doing_email() || nsrwc_is_doing_pdf() ) {
-		return '<img src="' . plugins_url( 'assets/icons/png/' . $config['png'], __FILE__ ) . '" alt="' . esc_attr( $currency ) . '" style="vertical-align: middle; margin: 0 !important; height: 1em; font-size: inherit !important;">';
+		// Plain-text email parts must never carry markup.
+		if ( nsrwc_is_doing_plain_text_email() ) {
+			return $currency_symbol;
+		}
+
+		return '<img src="' . esc_url( plugins_url( 'assets/icons/png/' . $config['png'], __FILE__ ) ) . '" alt="' . esc_attr( $currency ) . '" style="vertical-align: middle; margin: 0 !important; height: 1em; font-size: inherit !important;">';
 	}
 
-	return $config['unicode'];
+	return $config['char'];
 }
 
-add_filter( 'woocommerce_currency_symbol', 'nsrwc_replace_gulf_currency_symbol', 10002, 2 );
+add_filter( 'woocommerce_currency_symbol', 'nsrwc_replace_gulf_currency_symbol', 20, 2 );
 
 /**
  * Replace Gulf currency symbols in the plural symbol array.
@@ -262,7 +443,7 @@ function nsrwc_replace_gulf_currency_symbols_array( $symbols ) {
 	return $symbols;
 }
 
-add_filter( 'woocommerce_currency_symbols', 'nsrwc_replace_gulf_currency_symbols_array', 10002, 1 );
+add_filter( 'woocommerce_currency_symbols', 'nsrwc_replace_gulf_currency_symbols_array', 20, 1 );
 
 /**
  * Add css style to emails.
@@ -273,12 +454,12 @@ add_filter( 'woocommerce_currency_symbols', 'nsrwc_replace_gulf_currency_symbols
  */
 function nsrwc_email_styles_filter( $css ) {
 	// Fix emails amount direction.
-	$css .= "
+	$css .= '
 	.woocommerce-Price-amount {
 		direction: ltr;
-		display:inline-block;
+		display: inline-block;
 	}
-	";
+	';
 
 	return $css;
 }
@@ -293,29 +474,62 @@ add_filter( 'woocommerce_email_styles', 'nsrwc_email_styles_filter', 10, 1 );
 function nsrwc_declare_features_compatibility() {
 	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__ );
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__ );
 	}
 }
 
 add_action( 'before_woocommerce_init', 'nsrwc_declare_features_compatibility', 10 );
 
 /**
+ * Track whether the email part currently rendering is the plain-text variant.
+ *
+ * @since 2.3
+ *
+ * @param mixed $order          Order object.
+ * @param bool  $sent_to_admin  Whether the email goes to an admin.
+ * @param bool  $plain_text     Whether this is the plain-text part.
+ *
+ * @return void
+ */
+function nsrwc_track_plain_text_email( $order = null, $sent_to_admin = false, $plain_text = false ) {
+	$GLOBALS['nsrwc_plain_text_email'] = (bool) $plain_text;
+}
+
+add_action( 'woocommerce_email_order_details', 'nsrwc_track_plain_text_email', 1, 3 );
+
+/**
+ * Whether the email part currently rendering is plain text.
+ *
+ * @since 2.3
+ *
+ * @return bool
+ */
+function nsrwc_is_doing_plain_text_email() {
+	return ! empty( $GLOBALS['nsrwc_plain_text_email'] );
+}
+
+/**
  * Check if it is an email process.
+ *
+ * Every check is scoped to an action that is currently executing. `did_action()`
+ * must not be used here: it stays true for the rest of the request, which would
+ * leak the raster image into every price rendered afterwards — including REST
+ * responses and product feeds generated in the same request.
  *
  * @return bool
  */
 function nsrwc_is_doing_email() {
-	if (
+	return (
 		doing_action( 'woocommerce_email_header' ) ||
 		doing_action( 'woocommerce_email_footer' ) ||
 		doing_action( 'woocommerce_email_order_details' ) ||
 		doing_action( 'woocommerce_email_order_meta' ) ||
 		doing_action( 'woocommerce_email_attachments' ) ||
-		did_action( 'woocommerce_before_email_order' )
-	) {
-		return true;
-	}
-
-	return false;
+		doing_action( 'woocommerce_email_before_order_table' ) ||
+		doing_action( 'woocommerce_email_after_order_table' ) ||
+		doing_action( 'woocommerce_email_customer_details' ) ||
+		doing_action( 'woocommerce_before_email_order' )
+	);
 }
 
 /**
@@ -324,18 +538,13 @@ function nsrwc_is_doing_email() {
  * @return bool
  */
 function nsrwc_is_doing_pdf() {
-	if ( ! wp_doing_ajax() || ! isset( $_GET['action'] ) ) {
+	if ( ! wp_doing_ajax() || ! isset( $_GET['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only context probe.
 		return false;
 	}
 
-	if (
-		'generate_wpo_wcpdf' === $_GET['action'] ||
-		'wpifw_generate_invoice' === $_GET['action']
-	) {
-		return true;
-	}
+	$action = sanitize_key( wp_unslash( $_GET['action'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only context probe.
 
-	return false;
+	return in_array( $action, array( 'generate_wpo_wcpdf', 'wpifw_generate_invoice' ), true );
 }
 
 /**
@@ -359,7 +568,8 @@ function nsrwc_is_seo_or_llm_bot(): bool {
 	}
 
 	if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
-		return $is_bot = false;
+		$is_bot = false;
+		return $is_bot;
 	}
 
 	$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
@@ -367,17 +577,33 @@ function nsrwc_is_seo_or_llm_bot(): bool {
 	$bot_tokens = array(
 		// SEO crawlers.
 		'Googlebot',
+		'Google-InspectionTool',
+		'Storebot-Google',
+		'AdsBot-Google',
+		'Google-Shopping',
+		'Googlebot-Image',
 		'Bingbot',
+		'AdIdxBot',
 		'Slurp',
 		'DuckDuckBot',
 		'Baiduspider',
 		'YandexBot',
+		// Social / ad platform crawlers.
+		'facebookexternalhit',
+		'facebookcatalog',
+		'meta-externalagent',
+		'Twitterbot',
+		'Pinterestbot',
+		'TikTokSpider',
+		'SnapchatAds',
 		// LLM / AI crawlers.
 		'GPTBot',
+		'OAI-SearchBot',
+		'ChatGPT-User',
 		'ClaudeBot',
+		'Claude-Web',
 		'PerplexityBot',
 		'Applebot',
-		'meta-externalagent',
 		'Bytespider',
 		'cohere-ai',
 		'anthropic-ai',


### PR DESCRIPTION
## Why

[woocommerce/woocommerce#56337 (comment)](https://github.com/woocommerce/woocommerce/issues/56337#issuecomment-4917884589) reports this plugin "causes problems with ad platforms and pixel readings". It does, and the cause is architectural: the glyph was injected into `woocommerce_currency_symbol`, which is not just what templates print — it is also what product feeds, the REST API, exports, admin JS and payment integrations read. Anything that treats the symbol as data got a Private Use Area character, an HTML entity, or a full `<img>` tag.

This makes the glyph **presentation-only**. Every replacement now passes through one gate, `nsrwc_should_render_glyph()`, which falls back to WooCommerce's own symbol in machine contexts and is overridable by third parties.

All findings below were reproduced against **WooCommerce 11.1.0-beta.2 / WordPress 7.1** in wp-env, with Google Analytics for WooCommerce and Product Feed PRO installed, and re-verified after the fix.

## Findings and fixes

| # | Problem | Evidence | Fix |
|---|---|---|---|
| 1 | **Product feeds got the symbol instead of the price.** Feed plugins parse `wc_price()` output; AdTribes keys on `/<bdi>(.*?)&nbsp;/`. Forcing the currency position to `left_space` inserted that `&nbsp;`, so the captured "price" was `<span class="woocommerce-Price-currencySymbol">…</span>`. | `separator_price` captured the symbol span | Stop forcing the position; feed regex no longer matches |
| 2 | **"Currency position" setting was permanently overridden** via an `option_woocommerce_currency_pos` filter. Merchants could not change it, and `get_option()` never matched the stored value. | DB `right`, `get_option()` → `left_space` | Filter removed; spacing done in CSS, keyed off a body class |
| 3 | **Unbounded recursion** with multi-currency plugins that read the currency position while resolving the active currency. | one `get_option()` call recursed 300+ levels | No `option_` filter, so no cycle (depth 0) |
| 4 | **Email `<img>` leaked into the whole request.** `did_action()` stays true once fired, so after an order email every later price carried an `<img>` tag — Store API responses and feeds included. | Store API `currency_symbol` returned `<img src=…>` | `doing_action()` only |
| 5 | **Plain-text emails** received that `<img>` tag as literal text. | — | Plain-text parts get the standard symbol |
| 6 | **Symbol was an HTML entity**, so consumers treating it as text printed a literal `&#x20c1;`. | `wc_clean( wc_price() )` → `&#x20c1;&nbsp;199.99` | Real character (U+20C1) |
| 7 | **Priority 10002 beat every other plugin.** A normal-priority filter was silently ignored — the "not compatible with other plugins" complaint, literally. | filter at 20 lost; only 99999 won | Priority 20 + `nsrwc_render_glyph` filter |
| 8 | **Tofu on non-Gulf stores.** Symbols were replaced even when the webfont was never enqueued. | USD store still got `` for AED | Replacement gated on assets loading |
| 9 | **~24 currency resolutions per rendered price** (480 on a 20-product archive), each running multi-currency plugin logic. | — | Resolved once per request |
| 10 | **Digits changed font.** The JS tags the parent element, which holds the amount too, so the old `font-family: 'gulf-currencies', serif !important` restyled the numbers. | — | JS captures the element's own stack into `--nsrwc-font-stack`; only the glyph uses the bundled font |

## Codepoints

`U+20C1 SAUDI RIYAL SIGN` is confirmed against the current UCD (2025-08-15) as officially assigned, so SAR now emits a real, standards-correct character. **AED and OMR have no assigned codepoint** and still use Private Use Area values — which is exactly why they must never escape into data. That asymmetry is what motivated the machine-context gate.

## What still renders the glyph

Front-end pages, the Cart/Checkout blocks (Store API), the admin, and HTML emails (as the PNG). Machine contexts — REST outside the Store API, WP-CLI, cron, XML-RPC, feeds, and SEO/AI/ad crawlers — get WooCommerce's standard symbol.

## New extension points

- `nsrwc_render_glyph( bool $render, string $currency )` — force the standard symbol in any context.
- `nsrwc_load_assets( bool $load )` — force the webfont on for multi-currency stores with a non-Gulf base currency.
- `nsrwc_reset_currency_cache()` — for plugins that switch currency mid-request.

## Behaviour change to note

Stores relying on the forced "left with space" position now follow their **own** Currency position setting. The visual gap is preserved in CSS, so the default (`left`) looks the same; merchants who had explicitly chosen another position finally get it.

## Testing

- `phpcs --standard=WordPress` — clean on both PHP files.
- `PHPCompatibilityWP --runtime-set testVersion 7.4-` — clean.
- Verified in-browser: classic product page, block cart, Store API payload, HTML + plain-text order emails, Googlebot UA, custom REST namespace, and a simulated third-party override.
